### PR TITLE
feat: add memory.disable_global config option to skip global scope

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@Edison-A-N:registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@Edison-A-N/opencode-agent-memory",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Letta-style editable memory blocks for OpenCode.",
   "author": "Josh Thomas <josh@joshthomas.dev>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
-  "name": "opencode-agent-memory",
-  "version": "0.2.0",
+  "name": "@Edison-A-N/opencode-agent-memory",
+  "version": "0.2.1",
   "description": "Letta-style editable memory blocks for OpenCode.",
   "author": "Josh Thomas <josh@joshthomas.dev>",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/joshuadavidthomas/opencode-agent-memory"
+    "url": "https://github.com/Edison-A-N/opencode-agent-memory"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
   },
   "main": "src/plugin.ts",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@Edison-A-N/opencode-agent-memory",
-  "version": "0.3.0",
+  "version": "0.2.0-a1",
   "description": "Letta-style editable memory blocks for OpenCode.",
   "author": "Josh Thomas <josh@joshthomas.dev>",
   "license": "MIT",

--- a/src/journal.ts
+++ b/src/journal.ts
@@ -20,6 +20,11 @@ const ConfigSchema = z.looseObject({
       tags: z.array(TagSchema).optional(),
     })
     .optional(),
+  memory: z
+    .looseObject({
+      disable_global: z.boolean().optional(),
+    })
+    .optional(),
 });
 
 export type AgentMemoryConfig = z.infer<typeof ConfigSchema>;

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -173,12 +173,33 @@ function stableSortBlocks(blocks: MemoryBlock[]): MemoryBlock[] {
   return blocks;
 }
 
-export function createMemoryStore(projectDirectory: string): MemoryStore {
+export type MemoryStoreOptions = {
+  disableGlobal?: boolean;
+};
+
+export function createMemoryStore(
+  projectDirectory: string,
+  storeOpts?: MemoryStoreOptions,
+): MemoryStore {
+  const disableGlobal = storeOpts?.disableGlobal === true;
+
+  function assertGlobalAllowed(scope: MemoryScope): void {
+    if (disableGlobal && scope === "global") {
+      throw new Error(
+        "Global memory scope is disabled. Only project-scoped memory blocks are available.",
+      );
+    }
+  }
+
   return {
     async ensureSeed() {
       await ensureGitignore(projectDirectory);
 
       for (const seed of SEED_BLOCKS) {
+        if (disableGlobal && seed.scope === "global") {
+          continue;
+        }
+
         const dir = scopeDir(projectDirectory, seed.scope);
         await fs.mkdir(dir, { recursive: true });
 
@@ -198,7 +219,15 @@ export function createMemoryStore(projectDirectory: string): MemoryStore {
     },
 
     async listBlocks(scope) {
-      const scopes: MemoryScope[] = scope === "all" ? ["global", "project"] : [scope];
+      let scopes: MemoryScope[];
+      if (scope === "all") {
+        scopes = disableGlobal ? ["project"] : ["global", "project"];
+      } else {
+        if (disableGlobal && scope === "global") {
+          return [];
+        }
+        scopes = [scope];
+      }
       const blocks: MemoryBlock[] = [];
 
       for (const s of scopes) {
@@ -225,6 +254,7 @@ export function createMemoryStore(projectDirectory: string): MemoryStore {
     },
 
     async getBlock(scope, label) {
+      assertGlobalAllowed(scope);
       const safeLabel = validateLabel(label);
       const dir = scopeDir(projectDirectory, scope);
       const filePath = path.join(dir, `${safeLabel}.md`);
@@ -237,6 +267,7 @@ export function createMemoryStore(projectDirectory: string): MemoryStore {
     },
 
     async setBlock(scope, label, value, opts) {
+      assertGlobalAllowed(scope);
       const safeLabel = validateLabel(label);
       const dir = scopeDir(projectDirectory, scope);
       await fs.mkdir(dir, { recursive: true });
@@ -267,6 +298,7 @@ export function createMemoryStore(projectDirectory: string): MemoryStore {
     },
 
     async replaceInBlock(scope, label, oldText, newText) {
+      assertGlobalAllowed(scope);
       const block = await this.getBlock(scope, label);
       if (block.readOnly) {
         throw new Error(`Memory block is read-only: ${scope}:${block.label}`);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -18,11 +18,13 @@ import {
 import type { JournalContext } from "./tools";
 
 export const MemoryPlugin: Plugin = async ({ directory }) => {
-  const store = createMemoryStore(directory);
+  const config = await loadConfig();
+  const disableGlobal = config.memory?.disable_global === true;
+
+  const store = createMemoryStore(directory, { disableGlobal });
   await store.ensureSeed();
 
   // Journal: opt-in via ~/.config/opencode/agent-memory.json
-  const config = await loadConfig();
   const journalEnabled = config.journal?.enabled === true;
 
   // Mutable state updated by chat.message hook
@@ -70,9 +72,9 @@ export const MemoryPlugin: Plugin = async ({ directory }) => {
     },
 
     tool: {
-      memory_list: MemoryList(store),
-      memory_set: MemorySet(store),
-      memory_replace: MemoryReplace(store),
+      memory_list: MemoryList(store, { disableGlobal }),
+      memory_set: MemorySet(store, { disableGlobal }),
+      memory_replace: MemoryReplace(store, { disableGlobal }),
       ...journalTools,
     },
   };

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3,14 +3,22 @@ import { tool } from "@opencode-ai/plugin";
 import type { JournalStore } from "./journal";
 import type { MemoryScope, MemoryStore } from "./memory";
 
-export function MemoryList(store: MemoryStore) {
+export type MemoryToolOptions = {
+  disableGlobal?: boolean;
+};
+
+export function MemoryList(store: MemoryStore, opts?: MemoryToolOptions) {
+  const disableGlobal = opts?.disableGlobal === true;
+  const scopeValues = disableGlobal
+    ? (["all", "project"] as const)
+    : (["all", "global", "project"] as const);
+
   return tool({
     description: "List available memory blocks (labels, descriptions, sizes).",
     args: {
-      scope: tool.schema.enum(["all", "global", "project"]).optional(),
+      scope: tool.schema.enum(scopeValues).optional(),
     },
     async execute(args) {
-      // Default to "all" for list (show everything)
       const scope = (args.scope ?? "all") as MemoryScope | "all";
       const blocks = await store.listBlocks(scope);
       if (blocks.length === 0) {
@@ -27,18 +35,22 @@ export function MemoryList(store: MemoryStore) {
   });
 }
 
-export function MemorySet(store: MemoryStore) {
+export function MemorySet(store: MemoryStore, opts?: MemoryToolOptions) {
+  const disableGlobal = opts?.disableGlobal === true;
+  const scopeValues = disableGlobal
+    ? (["project"] as const)
+    : (["global", "project"] as const);
+
   return tool({
     description: "Create or update a memory block (full overwrite).",
     args: {
       label: tool.schema.string(),
-      scope: tool.schema.enum(["global", "project"]).optional(),
+      scope: tool.schema.enum(scopeValues).optional(),
       value: tool.schema.string(),
       description: tool.schema.string().optional(),
       limit: tool.schema.number().int().positive().optional(),
     },
     async execute(args) {
-      // Default to "project" for mutations (safer default)
       const scope = (args.scope ?? "project") as MemoryScope;
       await store.setBlock(scope, args.label, args.value, {
         description: args.description,
@@ -49,17 +61,21 @@ export function MemorySet(store: MemoryStore) {
   });
 }
 
-export function MemoryReplace(store: MemoryStore) {
+export function MemoryReplace(store: MemoryStore, opts?: MemoryToolOptions) {
+  const disableGlobal = opts?.disableGlobal === true;
+  const scopeValues = disableGlobal
+    ? (["project"] as const)
+    : (["global", "project"] as const);
+
   return tool({
     description: "Replace a substring within a memory block.",
     args: {
       label: tool.schema.string(),
-      scope: tool.schema.enum(["global", "project"]).optional(),
+      scope: tool.schema.enum(scopeValues).optional(),
       oldText: tool.schema.string(),
       newText: tool.schema.string(),
     },
     async execute(args) {
-      // Default to "project" for mutations (safer default)
       const scope = (args.scope ?? "project") as MemoryScope;
       await store.replaceInBlock(scope, args.label, args.oldText, args.newText);
       return `Updated memory block ${scope}:${args.label}.`;


### PR DESCRIPTION
## Summary

This PR adds a `memory.disable_global` configuration option (via `~/.config/opencode/agent-memory.json`) that allows users to completely disable the global memory scope, restricting all memory operations to project-scoped blocks only.

## Motivation

In multi-project environments, global memory blocks (`persona`, `human`) are shared across **all** projects. This can cause unintended issues:

- **Context leakage**: project A's preferences/conventions pollute project B's agent context
- **Unpredictable behavior**: agents carry over stale or irrelevant global state across different codebases
- **Sensitive data**: information written to global blocks becomes visible in every project

For users who run OpenCode across many distinct projects, the ability to opt out of global memory is essential.

## Changes

### Configuration

New field in `~/.config/opencode/agent-memory.json`:

```json
{
  "memory": {
    "disable_global": true
  }
}
```

### Behavioral changes when `disable_global: true`

| Operation | Before | After |
|-----------|--------|-------|
| `ensureSeed()` | Creates `persona` + `human` + `project` | Only creates `project` |
| `listBlocks("global")` | Returns global blocks | Returns `[]` |
| `listBlocks("all")` | Returns global + project | Returns project only |
| `setBlock("global", ...)` | Writes to global | Throws error |
| `replaceInBlock("global", ...)` | Replaces in global | Throws error |

### Files changed

- **`src/journal.ts`** — Added `memory.disable_global` to config schema (`ConfigSchema`)
- **`src/memory.ts`** — Added `MemoryStoreOptions.disableGlobal`; `createMemoryStore()` accepts options and gates all global-scope operations
- **`src/plugin.ts`** — Reads config and passes `disableGlobal` to memory store
- **`src/tools.ts`** — Propagates store options through tool definitions
- **`package.json`** — Published as `@Edison-A-N/opencode-agent-memory` on GitHub Packages for testing
- **`.npmrc`** — GitHub Packages registry config (can be removed if merged upstream)

## Questions for maintainer

Hi @joshuadavidthomas 👋

I've been using this plugin in a multi-project setup and found that global memory blocks were causing cross-project interference. This PR is my attempt to address that — I'd love your feedback on a few things:

1. **Is this the right approach?** Adding a config flag felt minimally invasive, but I'm open to alternative designs (e.g., a per-project override, or making global scope opt-in rather than opt-out).

2. **Config location**: I added `memory.disable_global` to the existing `agent-memory.json` config schema alongside `journal`. Does this feel right, or would you prefer a different structure?

3. **Scope of the PR**: The `.npmrc` and `package.json` changes are specific to my fork's publishing setup. Happy to clean those up if this is headed toward a merge.

4. **Testing**: The existing tests pass. I haven't added dedicated tests for `disable_global` yet — happy to add them if the approach looks good.

Thank you for building this plugin — the Letta-style memory model is a great fit for OpenCode. Looking forward to your thoughts!