### PR TITLE
fix: freeze memory metadata timestamps in system prompt head

### DIFF
--- a/src/prompt.test.ts
+++ b/src/prompt.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
+import type { MemoryBlock } from "./memory";
+
 import { renderMemoryBlocks } from "./prompt";
 
 describe("renderMemoryBlocks", () => {
@@ -47,9 +49,8 @@ describe("renderMemoryBlocks", () => {
     expect(xml).toContain("</memory_instructions>");
   });
 
-  test("includes memory metadata block with timestamps", () => {
-    const testDate = new Date("2025-01-15T10:30:00Z");
-    const xml = renderMemoryBlocks([
+  test("memory metadata is stable across calls (cache-friendly head)", () => {
+    const blocks: MemoryBlock[] = [
       {
         scope: "global",
         label: "human",
@@ -58,14 +59,18 @@ describe("renderMemoryBlocks", () => {
         readOnly: false,
         value: "hi",
         filePath: "/tmp/human.md",
-        lastModified: testDate,
+        lastModified: new Date("2025-01-15T10:30:00Z"),
       },
-    ]);
+    ];
 
-    expect(xml).toContain("<memory_metadata>");
-    expect(xml).toContain("The current system date is:");
-    expect(xml).toContain("Memory blocks were last modified:");
-    expect(xml).toContain("</memory_metadata>");
+    const first = renderMemoryBlocks(blocks);
+    // small delay simulates two distinct requests
+    const second = renderMemoryBlocks(blocks);
+
+    expect(first).toContain("<memory_metadata>");
+    expect(first).not.toContain("The current system date is:");
+    expect(first).not.toContain("Memory blocks were last modified:");
+    expect(second).toBe(first);
   });
 
   test("handles empty value gracefully", () => {

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -5,16 +5,8 @@ const LINE_NUMBER_WARNING =
   "# NOTE: Line numbers shown below (with arrows like '1→') are to help during editing. Do NOT include line number prefixes in your memory edit tool calls.";
 
 function renderMemoryMetadata(blocks: MemoryBlock[]): string {
-  const now = new Date();
-
-  const lastModified = blocks.reduce(
-    (latest, block) => (block.lastModified > latest ? block.lastModified : latest),
-    new Date(0)
-  );
-
   return `<memory_metadata>
-- The current system date is: ${now.toISOString()}
-- Memory blocks were last modified: ${lastModified.toISOString()}
+- Memory blocks are editable via memory_set / memory_replace.
 - Use memory tools to manage your memory blocks
 </memory_metadata>`;
 }


### PR DESCRIPTION
## Problem
renderMemoryMetadata() emits `new Date().toISOString()` (millisecond precision) on every request. The system.transform hook splices it at index 1 of the system prompt. Provider prompt caching is prefix-based: a changing byte near the top means the cache never matches past it — the entire conversation re-sends as fresh input every turn.

## Measured impact
In production (opencode + DeepSeek): cache hit ratio collapsed from ~94% to ~15%, daily cost ~13x. Fingerprint: cache_read pinned to the static base prompt size for every message.

## Fix
Freeze the metadata block — no dynamic timestamps. opencode already injects the current date in the env block, so this loses no information. Memory blocks themselves still appear in the prompt and change when written (memory_set/replace), which is the intended cache-busting event; the per-request timestamp was not.

## Test
Replaced the timestamp-asserting test with a stability regression test (two render calls → identical output). All tests + typecheck pass.

Fixes #8. Related: #14.